### PR TITLE
:tada: Add commented out fields with `shelf snapshot --edit`

### DIFF
--- a/src/shelf/schemas.py
+++ b/src/shelf/schemas.py
@@ -5,6 +5,11 @@ SNAPSHOT_SCHEMA_FILE = Path(__file__).parent / "snapshot-v1.schema.json"
 TABLE_SCHEMA_FILE = Path(__file__).parent / "table-v1.schema.json"
 SHELF_SCHEMA_FILE = Path(__file__).parent / "shelf-v1.schema.json"
 
+def validate_snapshot(snapshot: dict) -> None:
+    # Prune missing values
+    pruned_snapshot = {k: v for k, v in snapshot.items() if v is not None}
+    jsonschema.validate(pruned_snapshot, SNAPSHOT_SCHEMA)
+
 SNAPSHOT_SCHEMA = json.loads(SNAPSHOT_SCHEMA_FILE.read_text())
 TABLE_SCHEMA = json.loads(TABLE_SCHEMA_FILE.read_text())
 SHELF_SCHEMA = json.loads(SHELF_SCHEMA_FILE.read_text())

--- a/src/shelf/schemas.py
+++ b/src/shelf/schemas.py
@@ -1,4 +1,5 @@
 import json
+import jsonschema
 from pathlib import Path
 
 SNAPSHOT_SCHEMA_FILE = Path(__file__).parent / "snapshot-v1.schema.json"

--- a/src/shelf/snapshots.py
+++ b/src/shelf/snapshots.py
@@ -108,14 +108,12 @@ class Snapshot:
         record = self.to_dict()
         jsonschema.validate(record, SNAPSHOT_SCHEMA)
 
-        save_yaml(record, self.metadata_path)
+        save_yaml(record, self.metadata_path, include_comments=True)
 
     def to_dict(self) -> dict:
         record = asdict(self)
         record["uri"] = str(self.uri)
-        for k in [k for k, v in record.items() if v is None]:
-            del record[k]
-
+        # Include all fields, even if they are None
         return record
 
     @staticmethod

--- a/src/shelf/snapshots.py
+++ b/src/shelf/snapshots.py
@@ -106,7 +106,7 @@ class Snapshot:
     def save(self):
         # prep the metadata record
         record = self.to_dict()
-        jsonschema.validate(record, SNAPSHOT_SCHEMA)
+        validate_snapshot(record)
 
         save_yaml(record, self.metadata_path, include_comments=True)
 

--- a/src/shelf/snapshots.py
+++ b/src/shelf/snapshots.py
@@ -16,7 +16,7 @@ import boto3
 import jsonschema
 
 from shelf.paths import BASE_DIR, SNAPSHOT_DIR
-from shelf.schemas import SNAPSHOT_SCHEMA
+from shelf.schemas import SNAPSHOT_SCHEMA, validate_snapshot
 from shelf.types import Checksum, DatasetName, FileName, Manifest, StepURI
 from shelf.utils import (
     checksum_file,

--- a/src/shelf/utils.py
+++ b/src/shelf/utils.py
@@ -65,13 +65,21 @@ def add_to_gitignore(path: Path) -> None:
         print(path.relative_to(BASE_DIR), file=f)
 
 
-def save_yaml(obj: dict, path: Path) -> None:
+def save_yaml(obj: dict, path: Path, include_comments: bool = False) -> None:
     if path.exists():
         print_op("UPDATE", path)
     else:
         print_op("CREATE", path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(yaml.safe_dump(obj, sort_keys=False))
+    with open(path, "w") as f:
+        if include_comments:
+            for key, value in obj.items():
+                if value is None:
+                    f.write(f"# {key}: \n")
+                else:
+                    yaml.dump({key: value}, f, sort_keys=False)
+        else:
+            yaml.dump(obj, f, sort_keys=False)
 
 
 def load_yaml(path: Path) -> Any:

--- a/src/shelf/utils.py
+++ b/src/shelf/utils.py
@@ -65,6 +65,13 @@ def add_to_gitignore(path: Path) -> None:
         print(path.relative_to(BASE_DIR), file=f)
 
 
+def dump_yaml_with_comments(obj: dict, f) -> None:
+    for key, value in obj.items():
+        if value is None:
+            f.write(f"# {key}: \n")
+        else:
+            yaml.dump({key: value}, f, sort_keys=False)
+
 def save_yaml(obj: dict, path: Path, include_comments: bool = False) -> None:
     if path.exists():
         print_op("UPDATE", path)
@@ -73,11 +80,7 @@ def save_yaml(obj: dict, path: Path, include_comments: bool = False) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as f:
         if include_comments:
-            for key, value in obj.items():
-                if value is None:
-                    f.write(f"# {key}: \n")
-                else:
-                    yaml.dump({key: value}, f, sort_keys=False)
+            dump_yaml_with_comments(obj, f)
         else:
             yaml.dump(obj, f, sort_keys=False)
 


### PR DESCRIPTION
Make it easier to add new snapshots with `--edit` by adding the missing metadata fields there.