### PR TITLE
:tada: add export-duckdb subcommand to export tables to DuckDB file with unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "ruff>=0.5.5",
     "rich>=13.7.1",
     "polars>=1.4.0",
+    "duckdb>=1.0.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/src/shelf/schemas.py
+++ b/src/shelf/schemas.py
@@ -6,10 +6,12 @@ SNAPSHOT_SCHEMA_FILE = Path(__file__).parent / "snapshot-v1.schema.json"
 TABLE_SCHEMA_FILE = Path(__file__).parent / "table-v1.schema.json"
 SHELF_SCHEMA_FILE = Path(__file__).parent / "shelf-v1.schema.json"
 
+
 def validate_snapshot(snapshot: dict) -> None:
     # Prune missing values
     pruned_snapshot = {k: v for k, v in snapshot.items() if v is not None}
     jsonschema.validate(pruned_snapshot, SNAPSHOT_SCHEMA)
+
 
 SNAPSHOT_SCHEMA = json.loads(SNAPSHOT_SCHEMA_FILE.read_text())
 TABLE_SCHEMA = json.loads(TABLE_SCHEMA_FILE.read_text())

--- a/src/shelf/utils.py
+++ b/src/shelf/utils.py
@@ -72,6 +72,7 @@ def dump_yaml_with_comments(obj: dict, f) -> None:
         else:
             yaml.dump({key: value}, f, sort_keys=False)
 
+
 def save_yaml(obj: dict, path: Path, include_comments: bool = False) -> None:
     if path.exists():
         print_op("UPDATE", path)


### PR DESCRIPTION
Exports all tables to a duckdb file for easy querying.
